### PR TITLE
Added draft api_version document

### DIFF
--- a/api_versioning.md
+++ b/api_versioning.md
@@ -2,45 +2,33 @@
 
 ## Version Strategy
 
-All production APIs should use [Semantic Versioning](http://semver.org/) for
-generating version numbers however it should be limited to MAJOR and MINOR
-releases only.
+All production APIs should use [Semantic Versioning](http://semver.org/) for generating version numbers. That being said, APIs versions should be limited to MAJOR and MINOR releases only.
 
 Versions should be changed under the following circumstances:
-  * The format of a request to the API has change
+  * The format of a request to the API has changed
   * The format of a response from the API has changed
   * The meaning of any data in either a request or response has changed
 
-An API's version should be incremented sparingly and should be tied to a
-collection of work. Examples include:
+An API's version should be incremented sparingly and should be tied to a collection of work. Examples include:
   * A planned feature set
   * A time period's (most likely a sprint) worth of minor tweaks
 
+This serves to reduce the frequency of deploys, which are expensive in terms of effort required.
+
 ## Deprecation
 
-All production APIs should deprecate previous major versions as soon as
-possible, keeping no more than one previous major version active. As an
-example, as version 3.0 is being scheduled for release version 1.x should
-be scheduled for deprecation.
+All production APIs should deprecate previous major versions as soon as possible, keeping no more than one previous major version active. As an example, as version 3.0 is being scheduled for release version 1.x should be scheduled for deprecation.
 
-When a version is scheduled to be deprecated a message should be included
-in the header of every API response from that version containing the
-expected deprecation date. Any client's using the API should parse the
-message and inform the end user that an update of the client will be required
-before the expiry date.
+Versions should be deprecated and removed as soon as possible, in order to reduce the total cost of maintenance.
 
-Once the version has been deprecated, controllers/decorators/views relating to
-that version should be removed from the codebase.
+When a version is scheduled to be deprecated a message should be included in the header of every API response from that version containing the expected deprecation date. Any clients using the API should parse the message and inform the end user that an update of the client will be required before the expiry date.
+
+Once the version has been deprecated, controllers/decorators/views relating to that version should be removed from the codebase.
 
 ## Testing
 
-When writing API controller tests the tests should be as black box as possible
-passing in and validating against actual expected JSON strings to ensure the
-requests and responses meet the specifications for that version.
+When writing API controller tests the tests should be as black box as possible passing in and validating against actual expected JSON strings to ensure the requests and responses meet the specifications for that version.
 
-Once a test has been written for a version of an API controller, it should be considered
-immutable for the life cycle of that version to ensure any future changes are backwards
-compatible. If a new test is required this should be a good indication that the API
-version should be incremented.
+Once a test has been written for a version of an API controller, it should be considered immutable for the life cycle of that version to ensure any future changes are backwards compatible. If a new test is required this should be a good indication that the API version should be incremented.
 
 Only once an API version has been deprecated should the tests be removed.


### PR DESCRIPTION
This is a draft version of a document describe how we are going to handle API versioning in production moving forward. It is based on discussions between @jordanmaguire @Amerdrix and myself.
