### PR TITLE
Using parenthesis for method calls is optional

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -364,28 +364,6 @@
     payment_due ||= calculate_payment_due
     ```
 
-* Omit parentheses around parameters for methods that are part of an
-  internal DSL (e.g. Rake, Rails, RSpec), methods that have
-  "keyword" status in Ruby (e.g. `attr_reader`) and attribute
-  access methods. Use parentheses around the arguments of all other
-  method invocations.
-
-    ```Ruby
-    class Person
-      attr_reader :name, :age
-
-      # omitted
-    end
-
-    temperance = Person.new('Temperance', 30)
-    temperance.name
-
-    x = Math.sin(y)
-    array.delete(e)
-
-    bowling.score.should == 0
-    ```
-
 * Omit parentheses for method calls with no arguments.
 
     ```Ruby


### PR DESCRIPTION
Remove the requirement to always use parenthesis in method calls with arguments.

There are a lot of tradeoffs for using/excluding parenthesis, and it results in a lot of personal preference. By removing this requirement developers must exercise their own judgement in writing clear, readable, maintainable code. Code must always be clear, readable, and maintainable, regardless of whether braces are included or not.

Arguments put forward in favour of removing this (in no particular order):
- It can make code more like English; thus, making it faster and easier to read for some developers.
- Following the ruby community conventions is usually a good idea.
- It can add unnecessary clutter to the code (code junk).

Arguments put forward in favour of keeping it (in no particular order):
- Without brackets it looks more like English than code. Some developers find it harder to read.
- It can be ambiguous and clear about what is happening.
- Code never breaks by adding brackets, the inverse is not true.

Since the current plan is to make the TFG standard more general I want to pull this out. Some people like it, some don't. We'll never get 100% agreement. Let's ditch it from the standard and let developers make judgement calls.
