### PR TITLE
add standard for unitless zero-value in CSS

### DIFF
--- a/css.md
+++ b/css.md
@@ -27,6 +27,7 @@ This style guide focusses primarily on the usage of SASS, which is the standard 
 * Use two **spaces** per indentation level. No hard tabs.
 * Use one space after `:` in property declarations.
 * Use spaces after comma separated values, let the minifier take care of compression.
+* Avoid specifying units for zero values, e.g., `margin: 0` instead of `margin: 0px`.
 * Use hex color codes, shortening to the shorthand form where possible:
 
   ```sass


### PR DESCRIPTION
I vote for introducing unitless zero-values.
1. it's superfluous
2. unit-less makes it easier to read, as it is more distinguishable from other values with a unit
3. the SASS compiler will strip the unit from 0 values anyway
4. it has become a widely used standard amongst developers
5. It's part of many styleguides, eg:
   1. [Github](https://github.com/styleguide/css)
   2. [Google](http://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml#0_and_Units)
   3. [@necolas who created normalize.css](https://github.com/necolas/idiomatic-css#4-format)

AFAIK, TFG has always omitted units for zero-values.
