### PR TITLE
Add white-space: nowrap to visually-hidden helper

### DIFF
--- a/css.md
+++ b/css.md
@@ -318,6 +318,7 @@ Over time we have started using [Normalize.css](https://github.com/necolas/norma
   overflow: hidden
   padding: 0
   position: absolute
+  white-space: nowrap
   width: 1px
 
 // Form input placeholders


### PR DESCRIPTION
This prevents the accessible off-screen text from being smushed.

See: https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe

and discussion here: https://github.com/h5bp/html5-boilerplate/pull/1900